### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "~7.1.0",
     "@angular/platform-browser-dynamic": "~7.1.0",
     "@angular/router": "~7.1.0",
-    "bootstrap": "^4.1.3",
+    "bootstrap": ">=4.3.1",
     "core-js": "^2.5.4",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.6",


### PR DESCRIPTION
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/